### PR TITLE
UF-4607: Changed to default fetchtype (LAZY) to remove list duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 #config
 .env
-*.properties
+/*.properties
 
 ### Java ###
 # Compiled class file

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 #config
 .env
-application-default.properties
+*.properties
 
 ### Java ###
 # Compiled class file

--- a/src/main/java/se/sundsvall/supportmanagement/integration/db/model/ErrandEntity.java
+++ b/src/main/java/se/sundsvall/supportmanagement/integration/db/model/ErrandEntity.java
@@ -1,14 +1,20 @@
 package se.sundsvall.supportmanagement.integration.db.model;
 
-import org.hibernate.annotations.Formula;
-import org.hibernate.annotations.GenericGenerator;
+import static java.time.OffsetDateTime.now;
+import static java.time.ZoneId.systemDefault;
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -20,15 +26,9 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
-import static java.time.OffsetDateTime.now;
-import static java.time.ZoneId.systemDefault;
-import static java.time.temporal.ChronoUnit.MILLIS;
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "errand",
@@ -57,7 +57,7 @@ public class ErrandEntity implements Serializable {
 		uniqueConstraints = @UniqueConstraint(name = "uq_external_tag_errand_id_key", columnNames = { "errand_id", "key" }))
 	private List<DbExternalTag> externalTags;
 
-	@OneToMany(mappedBy = "errandEntity", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "errandEntity", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<StakeholderEntity> stakeholders;
 
 	@Column(name = "municipality_id", nullable = false)

--- a/src/main/java/se/sundsvall/supportmanagement/integration/db/model/StakeholderEntity.java
+++ b/src/main/java/se/sundsvall/supportmanagement/integration/db/model/StakeholderEntity.java
@@ -24,230 +24,227 @@ import javax.persistence.Table;
 @Table(name = "stakeholder")
 public class StakeholderEntity implements Serializable {
 
-    @Serial
-    private static final long serialVersionUID = 8197399712706968439L;
+	@Serial
+	private static final long serialVersionUID = 8197399712706968439L;
 
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "id")
-    private long id;
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "id")
+	private long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "errand_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "fk_errand_stakeholder_errand_id"))
-    private ErrandEntity errandEntity;
-    @Column(name = "external_id")
-    private String externalId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "errand_id", nullable = false, foreignKey = @ForeignKey(name = "fk_errand_stakeholder_errand_id"))
+	private ErrandEntity errandEntity;
+
+	@Column(name = "external_id")
+	private String externalId;
+
 	@Column(name = "external_id_type_tag")
-    private String externalIdTypeTag;
+	private String externalIdTypeTag;
 
-    @Column(name = "first_name")
-    private String firstName;
+	@Column(name = "first_name")
+	private String firstName;
 
-    @Column(name = "last_name")
-    private String lastName;
+	@Column(name = "last_name")
+	private String lastName;
 
-    @Column(name = "address")
-    private String address;
+	@Column(name = "address")
+	private String address;
 
-    @Column(name = "care_of")
-    private String careOf;
+	@Column(name = "care_of")
+	private String careOf;
 
-    @Column(name = "zip_code")
-    private String zipCode;
+	@Column(name = "zip_code")
+	private String zipCode;
 
-    @Column(name = "country")
-    private String country;
+	@Column(name = "country")
+	private String country;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "contact_channel",
-            joinColumns = @JoinColumn(name = "stakeholder_id",
-                    referencedColumnName = "id",
-                    foreignKey = @ForeignKey(name = "fk_stakeholder_contact_channel_stakeholder_id")
-            )
-    )
-    private List<ContactChannelEntity> contactChannels;
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "contact_channel", joinColumns = @JoinColumn(name = "stakeholder_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_stakeholder_contact_channel_stakeholder_id")))
+	private List<ContactChannelEntity> contactChannels;
 
-    public static StakeholderEntity create() {
-        return new StakeholderEntity();
-    }
+	public static StakeholderEntity create() {
+		return new StakeholderEntity();
+	}
 
-    public String getExternalId() {
-        return externalId;
-    }
+	public String getExternalId() {
+		return externalId;
+	}
 
-    public void setExternalId(String externalId) {
-        this.externalId = externalId;
-    }
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
+	}
 
-    public long getId() {
-        return id;
-    }
+	public long getId() {
+		return id;
+	}
 
-    public void setId(long id) {
-        this.id = id;
-    }
+	public void setId(long id) {
+		this.id = id;
+	}
 
-    public StakeholderEntity withId(long id) {
-        this.id = id;
-        return this;
-    }
+	public StakeholderEntity withId(long id) {
+		this.id = id;
+		return this;
+	}
 
-    public ErrandEntity getErrandEntity() {
-        return errandEntity;
-    }
+	public ErrandEntity getErrandEntity() {
+		return errandEntity;
+	}
 
-    public void setErrandEntity(ErrandEntity errandEntity) {
-        this.errandEntity = errandEntity;
-    }
+	public void setErrandEntity(ErrandEntity errandEntity) {
+		this.errandEntity = errandEntity;
+	}
 
-    public StakeholderEntity withErrandEntity(ErrandEntity errandEntity) {
-        this.errandEntity = errandEntity;
-        return this;
-    }
+	public StakeholderEntity withErrandEntity(ErrandEntity errandEntity) {
+		this.errandEntity = errandEntity;
+		return this;
+	}
 
-    public StakeholderEntity withExternalId(String externalId) {
-        this.externalId = externalId;
-        return this;
-    }
+	public StakeholderEntity withExternalId(String externalId) {
+		this.externalId = externalId;
+		return this;
+	}
 
-    public String getExternalIdTypeTag() {
-        return externalIdTypeTag;
-    }
+	public String getExternalIdTypeTag() {
+		return externalIdTypeTag;
+	}
 
-    public void setExternalIdTypeTag(String externalIdTypeTag) {
-        this.externalIdTypeTag = externalIdTypeTag;
-    }
+	public void setExternalIdTypeTag(String externalIdTypeTag) {
+		this.externalIdTypeTag = externalIdTypeTag;
+	}
 
-    public StakeholderEntity withExternalIdTypeTag(String externalIdTypeTag) {
-        this.externalIdTypeTag = externalIdTypeTag;
-        return this;
-    }
+	public StakeholderEntity withExternalIdTypeTag(String externalIdTypeTag) {
+		this.externalIdTypeTag = externalIdTypeTag;
+		return this;
+	}
 
-    public String getFirstName() {
-        return firstName;
-    }
+	public String getFirstName() {
+		return firstName;
+	}
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
 
-    public StakeholderEntity withFirstName(String firstName) {
-        this.firstName = firstName;
-        return this;
-    }
+	public StakeholderEntity withFirstName(String firstName) {
+		this.firstName = firstName;
+		return this;
+	}
 
-    public String getLastName() {
-        return lastName;
-    }
+	public String getLastName() {
+		return lastName;
+	}
 
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
 
-    public StakeholderEntity withLastName(String lastName) {
-        this.lastName = lastName;
-        return this;
-    }
+	public StakeholderEntity withLastName(String lastName) {
+		this.lastName = lastName;
+		return this;
+	}
 
-    public String getAddress() {
-        return address;
-    }
+	public String getAddress() {
+		return address;
+	}
 
-    public void setAddress(String address) {
-        this.address = address;
-    }
+	public void setAddress(String address) {
+		this.address = address;
+	}
 
-    public StakeholderEntity withAddress(String address) {
-        this.address = address;
-        return this;
-    }
+	public StakeholderEntity withAddress(String address) {
+		this.address = address;
+		return this;
+	}
 
-    public String getCareOf() {
-        return careOf;
-    }
+	public String getCareOf() {
+		return careOf;
+	}
 
-    public void setCareOf(String careOf) {
-        this.careOf = careOf;
-    }
+	public void setCareOf(String careOf) {
+		this.careOf = careOf;
+	}
 
-    public StakeholderEntity withCareOf(String careOf) {
-        this.careOf = careOf;
-        return this;
-    }
+	public StakeholderEntity withCareOf(String careOf) {
+		this.careOf = careOf;
+		return this;
+	}
 
-    public String getZipCode() {
-        return zipCode;
-    }
+	public String getZipCode() {
+		return zipCode;
+	}
 
-    public void setZipCode(String zipCode) {
-        this.zipCode = zipCode;
-    }
+	public void setZipCode(String zipCode) {
+		this.zipCode = zipCode;
+	}
 
-    public StakeholderEntity withZipCode(String zipCode) {
-        this.zipCode = zipCode;
-        return this;
-    }
+	public StakeholderEntity withZipCode(String zipCode) {
+		this.zipCode = zipCode;
+		return this;
+	}
 
-    public String getCountry() {
-        return country;
-    }
+	public String getCountry() {
+		return country;
+	}
 
-    public void setCountry(String country) {
-        this.country = country;
-    }
+	public void setCountry(String country) {
+		this.country = country;
+	}
 
-    public StakeholderEntity withCountry(String country) {
-        this.country = country;
-        return this;
-    }
+	public StakeholderEntity withCountry(String country) {
+		this.country = country;
+		return this;
+	}
 
-    public List<ContactChannelEntity> getContactChannels() {
-        return contactChannels;
-    }
+	public List<ContactChannelEntity> getContactChannels() {
+		return contactChannels;
+	}
 
-    public void setContactChannels(List<ContactChannelEntity> contactChannels) {
-        this.contactChannels = contactChannels;
-    }
+	public void setContactChannels(List<ContactChannelEntity> contactChannels) {
+		this.contactChannels = contactChannels;
+	}
 
-    public StakeholderEntity withContactChannels(List<ContactChannelEntity> contactChannels) {
-        this.contactChannels = contactChannels;
-        return this;
-    }
+	public StakeholderEntity withContactChannels(List<ContactChannelEntity> contactChannels) {
+		this.contactChannels = contactChannels;
+		return this;
+	}
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StakeholderEntity that = (StakeholderEntity) o;
-        return id == that.id && Objects.equals(errandEntity, that.errandEntity) && Objects.equals(externalId, that.externalId) && Objects.equals(externalIdTypeTag, that.externalIdTypeTag) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(address, that.address) && Objects.equals(careOf, that.careOf) && Objects.equals(zipCode, that.zipCode) && Objects.equals(country, that.country) && Objects.equals(contactChannels, that.contactChannels);
-    }
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		StakeholderEntity that = (StakeholderEntity) o;
+		return id == that.id && Objects.equals(errandEntity, that.errandEntity) && Objects.equals(externalId, that.externalId) && Objects.equals(externalIdTypeTag, that.externalIdTypeTag) && Objects.equals(firstName, that.firstName) && Objects
+			.equals(lastName, that.lastName) && Objects.equals(address, that.address) && Objects.equals(careOf, that.careOf) && Objects.equals(zipCode, that.zipCode) && Objects.equals(country, that.country) && Objects.equals(contactChannels,
+				that.contactChannels);
+	}
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, errandEntity, externalId, externalIdTypeTag, firstName, lastName, address, careOf, zipCode, country, contactChannels);
-    }
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, errandEntity, externalId, externalIdTypeTag, firstName, lastName, address, careOf, zipCode, country, contactChannels);
+	}
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("StakeholderEntity{");
-        sb.append("id=").append(id);
-        sb.append(", errandEntityId=").append(Optional.ofNullable(errandEntity).map(ErrandEntity::getId).orElse(null));
-        sb.append(", externalId='").append(externalId).append('\'');
-        sb.append(", externalIdTypeTag='").append(externalIdTypeTag).append('\'');
-        sb.append(", firstName='").append(firstName).append('\'');
-        sb.append(", lastName='").append(lastName).append('\'');
-        sb.append(", address='").append(address).append('\'');
-        sb.append(", careOf='").append(careOf).append('\'');
-        sb.append(", zipCode='").append(zipCode).append('\'');
-        sb.append(", country='").append(country).append('\'');
-        sb.append(", contactChannels=").append(contactChannels);
-        sb.append('}');
-        return sb.toString();
-    }
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("StakeholderEntity{");
+		sb.append("id=").append(id);
+		sb.append(", errandEntityId=").append(Optional.ofNullable(errandEntity).map(ErrandEntity::getId).orElse(null));
+		sb.append(", externalId='").append(externalId).append('\'');
+		sb.append(", externalIdTypeTag='").append(externalIdTypeTag).append('\'');
+		sb.append(", firstName='").append(firstName).append('\'');
+		sb.append(", lastName='").append(lastName).append('\'');
+		sb.append(", address='").append(address).append('\'');
+		sb.append(", careOf='").append(careOf).append('\'');
+		sb.append(", zipCode='").append(zipCode).append('\'');
+		sb.append(", country='").append(country).append('\'');
+		sb.append(", contactChannels=").append(contactChannels);
+		sb.append('}');
+		return sb.toString();
+	}
 }

--- a/src/test/java/se/sundsvall/supportmanagement/integration/db/ErrandsRepositoryTest.java
+++ b/src/test/java/se/sundsvall/supportmanagement/integration/db/ErrandsRepositoryTest.java
@@ -10,6 +10,8 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -112,6 +114,7 @@ class ErrandsRepositoryTest {
 	}
 
 	@Test
+	@Transactional
 	void errandWithStakeholderAndContactChannel() {
 		var errandEntity =  errandsRepository.findById("ERRAND_ID-1");
 


### PR DESCRIPTION
- Fetchtype EAGER uses outer join when fetching entities, which creates duplicates in result (see
https://stackoverflow.com/questions/20749806/duplicates-in-onetomany-annotated-list). Changed to default fetchtype LAZY to avoid duplicates.