### PR TITLE
UF-5039: Excluded created, modified and touched when comparing revisions

### DIFF
--- a/src/main/java/se/sundsvall/supportmanagement/integration/db/RevisionRepository.java
+++ b/src/main/java/se/sundsvall/supportmanagement/integration/db/RevisionRepository.java
@@ -3,14 +3,11 @@ package se.sundsvall.supportmanagement.integration.db;
 import java.util.List;
 import java.util.Optional;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.repository.CrudRepository;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import se.sundsvall.supportmanagement.integration.db.model.RevisionEntity;
 
-@Transactional
 @CircuitBreaker(name = "revisionRepository")
 public interface RevisionRepository extends CrudRepository<RevisionEntity, String> {
 

--- a/src/main/java/se/sundsvall/supportmanagement/service/RevisionService.java
+++ b/src/main/java/se/sundsvall/supportmanagement/service/RevisionService.java
@@ -14,6 +14,8 @@ import static se.sundsvall.supportmanagement.service.mapper.RevisionMapper.toSer
 import java.util.EnumSet;
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,12 +40,13 @@ import se.sundsvall.supportmanagement.service.mapper.ErrandNoteMapper;
 import se.sundsvall.supportmanagement.service.mapper.RevisionMapper;
 
 @Service
+@Transactional
 public class RevisionService {
 	private static final EnumSet<DiffFlags> DIFF_SETTINGS = EnumSet.of(ADD_ORIGINAL_VALUE_ON_REPLACE, OMIT_COPY_OPERATION, OMIT_MOVE_OPERATION);
 	private static final Configuration JSONPATH_CONFIG = defaultConfiguration().addOptions(SUPPRESS_EXCEPTIONS);
 	private static final Logger LOG = LoggerFactory.getLogger(RevisionService.class);
 
-	private static final List<String> EXCLUDED_ATTRIBUTES = List.of("$..stakeholders[*].id", "$..attachments[*].id", "$..attachments[*].file");
+	private static final List<String> EXCLUDED_ATTRIBUTES = List.of("$..stakeholders[*].id", "$..attachments[*].id", "$..attachments[*].file", "$..created", "$..modified", "$..touched");
 	private static final String COMPARISON_ERROR_LOG_MESSAGE = "An error occured during comparison";
 	private static final String COMPARISON_ERROR_PROBLEM = "An error occured when comparing version %s to version %s of entityId '%s'";
 	private static final String VERSION_DOES_NOT_EXIST = "The version requested for the %s revision does not exist";

--- a/src/test/java/se/sundsvall/supportmanagement/service/RevisionServiceTest.java
+++ b/src/test/java/se/sundsvall/supportmanagement/service/RevisionServiceTest.java
@@ -1,5 +1,6 @@
 package se.sundsvall.supportmanagement.service;
 
+import static java.time.Instant.ofEpochMilli;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,6 +15,7 @@ import static org.zalando.problem.Status.NOT_FOUND;
 import static se.sundsvall.supportmanagement.service.mapper.RevisionMapper.toSerializedSnapshot;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -459,7 +461,14 @@ class RevisionServiceTest {
 	private ErrandEntity createErrandEntity(String entityId) {
 		return ErrandEntity.create()
 			.withId(entityId)
-			.withAttachments(List.of(AttachmentEntity.create().withId(UUID.randomUUID().toString()).withFile(RandomUtils.nextBytes(30))))
+			.withCreated(OffsetDateTime.ofInstant(ofEpochMilli(RandomUtils.nextLong()), ZoneId.systemDefault()))
+			.withModified(OffsetDateTime.ofInstant(ofEpochMilli(RandomUtils.nextLong()), ZoneId.systemDefault()))
+			.withTouched(OffsetDateTime.ofInstant(ofEpochMilli(RandomUtils.nextLong()), ZoneId.systemDefault()))
+			.withAttachments(List.of(AttachmentEntity.create()
+				.withId(UUID.randomUUID().toString())
+				.withCreated(OffsetDateTime.ofInstant(ofEpochMilli(RandomUtils.nextLong()), ZoneId.systemDefault()))
+				.withModified(OffsetDateTime.ofInstant(ofEpochMilli(RandomUtils.nextLong()), ZoneId.systemDefault()))
+				.withFile(RandomUtils.nextBytes(30))))
 			.withStakeholders(List.of(StakeholderEntity.create().withId(RandomUtils.nextLong())));
 	}
 


### PR DESCRIPTION
- Added created, modified and touched attributes to exclusion filter as they can differ even though errand is not modified
- Moved transactional annotation from repository interface to service