### PR TITLE
HYDRAN-2650 SupportManagement – multiple recipients in the same email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-support-management</artifactId>
-	<version>14.11</version>
+	<version>14.12</version>
 	<name>api-service-support-management</name>
 	<properties>
 		<spring-filter.version>4.0.1</spring-filter.version>

--- a/src/integration-test/resources/ErrandCommunicationIT/__files/test01_sendEmail/mappings/api-messaging-send-email.json
+++ b/src/integration-test/resources/ErrandCommunicationIT/__files/test01_sendEmail/mappings/api-messaging-send-email.json
@@ -21,12 +21,15 @@
 							"83e13aaf-33aa-4aa2-ae31-abf46eaf0152@test.com"
 						]
 					},
-					"emailAddress": "john.a@zoidberg.com",
+					"recipients": [
+						"john.a@zoidberg.com"
+					],
 					"attachments": [],
 					"sender": {
 						"address": "bender@rodriguez.com",
 						"name": "Bender Bending Rodriguez"
 					},
+					"cc": [],
 					"subject": "Insane in the Mainframe",
 					"htmlMessage": "PGh0bWw+U29tZSBtZXNzYWdlIGFib3V0IHRoZSBIQUwgSW5zdGl0dXRlIGZvciA8Yj5DcmltaW5hbGx5IEluc2FuZSBSb2JvdHM8L2I+LCB3aGVyZSByb2JvdHMgdGhhdCA8aT5tdXJkZXJvdXNseTwvaT4gdHVybnMgYWdhaW5zdCBpdHMgaHVtYW4gY3JldyBhcmUgaGVsZDwvaHRtbD4=",
 					"message": "Some message about the HAL Institute for Criminally Insane Robots, where robots that murderously turns against its human crew are held",

--- a/src/integration-test/resources/ErrandCommunicationIT/__files/test02_sendEmailWithAttachments/mappings/api-messaging-send-email.json
+++ b/src/integration-test/resources/ErrandCommunicationIT/__files/test02_sendEmailWithAttachments/mappings/api-messaging-send-email.json
@@ -14,7 +14,9 @@
 							"${json-unit.ignore}"
 						]
 					},
-					"emailAddress": "turanga@leela.com",
+					"recipients": [
+						"turanga@leela.com"
+					],
 					"attachments": [
 						{
 							"name": "internet_history.png",
@@ -31,6 +33,7 @@
 						"address": "bender@rodriguez.com",
 						"name": "bender@rodriguez.com"
 					},
+					"cc": [],
 					"subject": "Attack of the Killer App",
 					"htmlMessage": "PGh0bWw+U2luY2Ugd2hlbiBpcyB0aGUgaW50ZXJuZXQgYWJvdXQgcm9iYmluZyBwZW9wbGUgb2YgdGhlaXIgcHJpdmFjeT8gPGk+U2luY2UgQXVndXN0IDYsIDE5OTEgd2hlbiB0aGUgV29ybGQgV2lkZSBXZWIgcHJvamVjdCB3YXMgYW5ub3VuY2VkPC9pPi48L2h0bWw+",
 					"message": "Since when is the internet about robbing people of their privacy? Since August 6, 1991 when the World Wide Web project was announced.",

--- a/src/integration-test/resources/ErrandCommunicationIT/__files/test06_sendEmailWithErrandAttachment/mappings/api-messaging-send-email.json
+++ b/src/integration-test/resources/ErrandCommunicationIT/__files/test06_sendEmailWithErrandAttachment/mappings/api-messaging-send-email.json
@@ -21,7 +21,9 @@
 							"83e13aaf-33aa-4aa2-ae31-abf46eaf0152@test.com"
 						]
 					},
-					"emailAddress": "john.a@zoidberg.com",
+					"recipients": [
+						"john.a@zoidberg.com"
+					],
 					"attachments": [
 						{
 							"name": "Test3.txt",
@@ -33,6 +35,7 @@
 						"address": "bender@rodriguez.com",
 						"name": "Bender Bending Rodriguez"
 					},
+					"cc": [],
 					"subject": "Insane in the Mainframe",
 					"htmlMessage": "PGh0bWw+U29tZSBtZXNzYWdlIGFib3V0IHRoZSBIQUwgSW5zdGl0dXRlIGZvciA8Yj5DcmltaW5hbGx5IEluc2FuZSBSb2JvdHM8L2I+LCB3aGVyZSByb2JvdHMgdGhhdCA8aT5tdXJkZXJvdXNseTwvaT4gdHVybnMgYWdhaW5zdCBpdHMgaHVtYW4gY3JldyBhcmUgaGVsZDwvaHRtbD4=",
 					"message": "Some message about the HAL Institute for Criminally Insane Robots, where robots that murderously turns against its human crew are held",

--- a/src/integration-test/resources/ErrandCommunicationIT/__files/test20_createInternalConversationMessageToReporter/mappings/api-messaging-send-email.json
+++ b/src/integration-test/resources/ErrandCommunicationIT/__files/test20_createInternalConversationMessageToReporter/mappings/api-messaging-send-email.json
@@ -18,7 +18,10 @@
 							}
 						]
 					},
-					"emailAddress": "robert.reporter@testdomain.local",
+					"recipients": [
+						"robert.reporter@testdomain.local"
+					],
+					"cc": [],
 					"subject": "Nytt meddelande kopplat till ärendet AP-23020003",
 					"message": "Som rapportör kan du kontakta oss via e-post eller telefon",
 					"sender": {

--- a/src/main/java/se/sundsvall/supportmanagement/service/mapper/MessagingMapper.java
+++ b/src/main/java/se/sundsvall/supportmanagement/service/mapper/MessagingMapper.java
@@ -66,7 +66,7 @@ public class MessagingMapper {
 			.attachments(Stream.of(attachments, toAttachments(emailRequest.getAttachments()))
 				.flatMap(List::stream)
 				.toList())
-			.emailAddress(emailRequest.getRecipient())
+			.recipients(ofNullable(emailRequest.getRecipient()).map(List::of).orElse(null))
 			.htmlMessage(addBase64Encoding(emailRequest.getHtmlMessage()))
 			.message(emailRequest.getMessage())
 			.party(toEmailRequestParty(errandEntity))

--- a/src/main/resources/integrations/messaging-api.yaml
+++ b/src/main/resources/integrations/messaging-api.yaml
@@ -2523,17 +2523,26 @@ components:
       description: Attachment
     EmailRequest:
       required:
-        - emailAddress
         - subject
       type: object
       properties:
         party:
           $ref: "#/components/schemas/EmailRequestParty"
         emailAddress:
-          minLength: 1
           type: string
-          description: Recipient e-mail address
+          deprecated: true
+          description: Recipient e-mail address. Deprecated, use 'recipients' instead
           format: email
+        recipients:
+          type: array
+          description: Recipient (To) e-mail addresses
+          items:
+            type: string
+        cc:
+          type: array
+          description: Carbon-copy (CC) e-mail addresses
+          items:
+            type: string
         subject:
           minLength: 1
           type: string

--- a/src/test/java/se/sundsvall/supportmanagement/service/CommunicationServiceTest.java
+++ b/src/test/java/se/sundsvall/supportmanagement/service/CommunicationServiceTest.java
@@ -442,7 +442,7 @@ class CommunicationServiceTest {
 		verify(errandAttachmentServiceMock).createErrandAttachment(any(AttachmentEntity.class), any(ErrandEntity.class));
 
 		final var arguments = messagingEmailCaptor.getValue();
-		assertThat(arguments.getEmailAddress()).isEqualTo(RECIPIENT);
+		assertThat(arguments.getRecipients()).containsExactly(RECIPIENT);
 		assertThat(new String(BASE64_DECODER.decode(arguments.getHtmlMessage()), StandardCharsets.UTF_8)).isEqualTo(HTML_MESSAGE);
 		assertThat(arguments.getMessage()).isEqualTo(PLAIN_MESSAGE);
 		assertThat(arguments.getParty().getPartyId()).isNull();
@@ -822,7 +822,7 @@ class CommunicationServiceTest {
 		assertThat(emailRequestCaptor.getValue()).satisfies(emailRequest -> {
 			assertThat(emailRequest.getSubject()).isEqualTo("Nytt meddelande kopplat till ärendet %s".formatted(errandNumber));
 			assertThat(emailRequest.getMessage()).isEqualToNormalizingUnicode(reporterSupportText);
-			assertThat(emailRequest.getEmailAddress()).isEqualTo(recieverEmail);
+			assertThat(emailRequest.getRecipients()).containsExactly(recieverEmail);
 			assertThat(emailRequest.getHtmlMessage()).isNull();
 			assertThat(emailRequest.getSender().getAddress()).isEqualTo(contactInformationEmail);
 			assertThat(emailRequest.getSender().getName()).isEqualTo(contactInformationName);

--- a/src/test/java/se/sundsvall/supportmanagement/service/mapper/MessagingMapperTest.java
+++ b/src/test/java/se/sundsvall/supportmanagement/service/mapper/MessagingMapperTest.java
@@ -90,7 +90,7 @@ class MessagingMapperTest {
 	void toEmailRequestWithSenderName() {
 		final var result = MessagingMapper.toEmailRequest(createErrandEntity(), createEmailRequest(true, HTML_MESSAGE_IN_BASE64), List.of());
 
-		assertThat(result.getEmailAddress()).isEqualTo(RECIPIENT);
+		assertThat(result.getRecipients()).containsExactly(RECIPIENT);
 		assertThat(new String(BASE64_DECODER.decode(result.getHtmlMessage()), StandardCharsets.UTF_8)).isEqualTo(HTML_MESSAGE);
 		assertThat(result.getMessage()).isEqualTo(MESSAGE);
 		assertThat(result.getSubject()).isEqualTo(SUBJECT);
@@ -115,7 +115,7 @@ class MessagingMapperTest {
 	void toEmailRequestWithoutSenderName() {
 		final var result = MessagingMapper.toEmailRequest(createErrandEntity(), createEmailRequest(false, HTML_MESSAGE), List.of());
 
-		assertThat(result.getEmailAddress()).isEqualTo(RECIPIENT);
+		assertThat(result.getRecipients()).containsExactly(RECIPIENT);
 		assertThat(new String(BASE64_DECODER.decode(result.getHtmlMessage()), StandardCharsets.UTF_8)).isEqualTo(HTML_MESSAGE);
 		assertThat(result.getMessage()).isEqualTo(MESSAGE);
 		assertThat(result.getSubject()).isEqualTo(SUBJECT);

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "14.11"
+  version: "14.12"
 servers:
 - url: http://localhost:54715
   description: Generated server url


### PR DESCRIPTION
## HYDRAN-2650

Adapts SupportManagement to Messaging's new recipient support (`recipients` array) instead of the singular `emailAddress`.

### Changes (plumbing)
- `MessagingMapper.toEmailRequest` now sets `recipients` instead of the deprecated `emailAddress`.
- Updated generated messaging client (`integrations/messaging-api.yaml`).
- **Version bump 14.11 → 14.12**; own `openapi.yaml` → 14.12.
- Updated unit tests and `ErrandCommunicationIT` WireMock mappings (`recipients` + `cc`).

### Scope
This PR is **plumbing only** — the current single-stakeholder resolution is unchanged (one recipient is resolved and sent as a single-element list). The decision on *who* to notify (multiple roles in one e-mail) is deferred to a later business phase.

### Test
`mvn verify` green: 2257 unit + 210 integration tests, JaCoCo 85/85, OpenAPI contract test.

> Requires Messaging 7.12 (#344) deployed first. Part of the multi-recipient work.